### PR TITLE
Fix character

### DIFF
--- a/LANGUAGE/TR/FDSETUP.DEF
+++ b/LANGUAGE/TR/FDSETUP.DEF
@@ -22,7 +22,7 @@ LANG_DE=Almanca
 LANG_EO=Esperanto
 LANG_NL=Felemenkçe
 LANG_TR=Türkçe
-LANG_RU=Rus�a
+LANG_RU=Rusça
 
 HELLO_FRAME=/w70 /h15 /c
 HELLO_OPTS=/w43 /h4 /c


### PR DESCRIPTION
When I noticed that Github fails to display the ç letter, I thought I'd fix it this way, to make it consistent. If it's already okay, and would display correctly on actual Installer, feel free to ignore PR.